### PR TITLE
use stripped template instead of flat

### DIFF
--- a/components/student/create/explore.js
+++ b/components/student/create/explore.js
@@ -139,11 +139,11 @@ export default function CreativityActivity() {
     doneTonic();
     doneSubdominant();
     doneDominant();
-    console.log('generate', tonicMotiveScore && startedVariationGeneration);
+    // console.log('generate', tonicMotiveScore && startedVariationGeneration);
     setTonicJson(tonicMotiveScore);
     setStartedVariationGeneration(true);
     console.log('generate', tonicMotiveScore && startedVariationGeneration);
-    console.log('tonicMotiveScore', tonicMotiveScore);
+    // console.log('tonicMotiveScore', tonicMotiveScore);
     console.log('tonicJson', tonicJson);
     // setSomeVar(true);
     // console.log(
@@ -155,17 +155,17 @@ export default function CreativityActivity() {
   }
 
   function doneTonic() {
-    console.log('doneTonic', tonicMotiveScore);
+    // console.log('doneTonic', tonicMotiveScore);
     setTonicJson(tonicMotiveScore);
   }
 
   function doneSubdominant() {
-    console.log('doneSubdominant', subdominantMotiveScore);
+    // console.log('doneSubdominant', subdominantMotiveScore);
     setSubdominantJson(subdominantMotiveScore);
   }
 
   function doneDominant() {
-    console.log('doneDominant', dominantMotiveScore);
+    // console.log('doneDominant', dominantMotiveScore);
     setDominantJson(dominantMotiveScore);
   }
 
@@ -208,9 +208,9 @@ export default function CreativityActivity() {
         orig={melodyJson}
         trim={1}
         onUpdate={(data) => {
-          console.log('data', data);
+          // console.log('data', data);
           tonicMotiveScore = data;
-          console.log('tonicMotiveScore', tonicMotiveScore);
+          // console.log('tonicMotiveScore', tonicMotiveScore);
         }}
       />
       {/* <Button variant="primary" onClick={doneTonic}>
@@ -250,7 +250,7 @@ export default function CreativityActivity() {
         trim={1}
         onUpdate={(data) => {
           subdominantMotiveScore = data;
-          console.log('subdominantMotiveScore', subdominantMotiveScore);
+          // console.log('subdominantMotiveScore', subdominantMotiveScore);
         }}
       />
       {/* <Button variant="primary" onClick={doneSubdominant}>
@@ -288,7 +288,7 @@ export default function CreativityActivity() {
         trim={1}
         onUpdate={(data) => {
           dominantMotiveScore = data;
-          console.log('dominantMotiveScore', dominantMotiveScore);
+          // console.log('dominantMotiveScore', dominantMotiveScore);
         }}
       />
       {/* <Button variant="primary" onClick={doneDominant}>

--- a/components/variationsFromMotiveScore.js
+++ b/components/variationsFromMotiveScore.js
@@ -20,7 +20,7 @@ function VariationsFromMotiveScore({
   // chordScaleBucket,
   instrumentName,
 }) {
-  console.log('got in variations', referenceScoreJSON);
+  // console.log('got in variations', referenceScoreJSON);
   // console.log('flat io embed log', scoreJSON, orig);
   // const [json, setJson] = useState('');
   const [embed, setEmbed] = useState();

--- a/lib/ref-melody-motive-score-orig.json
+++ b/lib/ref-melody-motive-score-orig.json
@@ -1,1 +1,409 @@
-{"score-partwise":{"$version":"3.1","identification":{"creator":{"content":"Brittany J. Green","$type":"composer"},"encoding":{"software":"Flat","encoding-date":"2023-12-03"},"source":"https://flat.io/score/62ec0df2c6f0b1001227613f-freedom-2040-the-tomorrow-we-ll-build-melody-concert-pitch-tc?sharingKey=30bc11ca0306e5d4955a135fd0bd723010fb082fe006f4dd505c36ade58ded13f494a810a480215bfe02b41e60f6972b5e69f40b5f2772291e75ada7fd8cd0b3"},"defaults":{"scaling":{"millimeters":"7.2319","tenths":"40"},"page-layout":{"page-height":"1545","page-width":"1194","page-margins":{"$type":"both","left-margin":"70","right-margin":"70","top-margin":"70","bottom-margin":"70"}},"system-layout":{"system-margins":{"left-margin":"0","right-margin":"0"},"system-distance":"121","top-system-distance":"70"},"appearance":{"line-width":[{"content":"0.7487","$type":"stem"},{"content":"5","$type":"beam"},{"content":"0.7487","$type":"staff"},{"content":"0.7487","$type":"light barline"},{"content":"5","$type":"heavy barline"},{"content":"0.7487","$type":"leger"},{"content":"0.7487","$type":"ending"},{"content":"0.7487","$type":"wedge"},{"content":"0.7487","$type":"enclosure"},{"content":"0.7487","$type":"tuplet bracket"}],"note-size":[{"content":"60","$type":"grace"},{"content":"60","$type":"cue"}],"distance":[{"content":"120","$type":"hyphen"},{"content":"7.5","$type":"beam"}]},"music-font":{"$font-family":"Bravura"},"staff-layout":{"staff-distance":"70.24433413072636"},"$adagio-systemBreakPolicy":{"maxNbMeasuresPerLine":4,"forbiddenCounts":{}}},"credit":[{"credit-type":"title","credit-words":"Freedom 2040: The Tomorrow We'll Build Melody - Concert Pitch TC"}],"part-list":{"score-part":[{"$id":"P1","part-name":{"content":"Concert Pitch","$print-object":"no"},"part-abbreviation":{"content":"Ob.","$print-object":"no"},"score-instrument":{"$id":"P1-I1","instrument-name":"SmartMusicSoftSynth","instrument-sound":"wind.reed.oboe","virtual-instrument":{}},"midi-device":"SmartMusicSoftSynth","midi-instrument":{"$id":"P1-I1","midi-channel":"2","midi-bank":"15489","midi-program":69,"pan":"-56"},"uuid":"b6e5faf5-e2d7-b2ab-0eaf-f6b5b8467ca8","voiceMapping":{"0":[0]},"staffMapping":[{"voices":[0],"mainVoiceIdx":0,"staffUuid":"74e64bc4-a81b-7f02-6ea3-61645a6a7739"}],"voiceIdxToUuidMapping":{"0":"97cd248f-79db-20ff-cb25-904a5dc735de"},"voiceUuidToIdxMapping":{"97cd248f-79db-20ff-cb25-904a5dc735de":0}}]},"part":[{"$id":"P1","measure":[{"$number":"1","$width":"178","harmony":[{"$default-y":"39","root":{"root-step":"E","root-alter":"-1"},"kind":{"content":"major","$halign":"center","$text":""},"$adagio-location":{"timePos":0,"dpq":8},"staff":"1","$placement":"above","noteBefore":-1}],"note":[{"staff":"1","voice":"1","duration":"8","pitch":{"octave":"4","step":"F"},"$adagio-location":{"timePos":0},"type":"quarter"},{"staff":"1","voice":"1","duration":"4","pitch":{"octave":"4","step":"G"},"$adagio-location":{"timePos":8},"type":"eighth","beam":{"$number":"1","content":"begin"}},{"staff":"1","voice":"1","duration":"4","pitch":{"octave":"4","step":"A","alter":"-1"},"$adagio-location":{"timePos":12},"type":"eighth","beam":{"$number":"1","content":"end"}},{"staff":"1","voice":"1","duration":"8","pitch":{"octave":"5","step":"C"},"$adagio-location":{"timePos":16},"type":"quarter"},{"staff":"1","voice":"1","duration":"8","pitch":{"octave":"4","step":"B","alter":"-1"},"$adagio-location":{"timePos":24},"type":"quarter"}],"attributes":[{"divisions":"8","time":{"beats":"4","beat-type":"4"},"clef":{"sign":"G","line":"2"},"key":{"fifths":"-3"},"staff-details":{"staff-lines":"5"},"$adagio-time":{"beats":"4","beat-type":"4"},"noteBefore":-1,"$adagio-location":{"timePos":0,"dpq":1}}],"$adagio-restsInsideBeams":false,"sound":[{"$adagio-swing":{"swing":false},"noteBefore":-1,"$adagio-location":{"timePos":0,"dpq":8}},{"$tempo":"120","noteBefore":-1,"$adagio-location":{"timePos":0,"dpq":8}}],"direction":[{"$placement":"above","staff":"1","$adagio-location":{"timePos":0},"direction-type":{"metronome":{"per-minute":"120","beat-unit":"quarter"}},"noteBefore":-1,"$adagio-isFirst":true}],"$adagio-beatsList":[1,1,1,1]}],"uuid":"b6e5faf5-e2d7-b2ab-0eaf-f6b5b8467ca8"}],"measure-list":{"score-measure":[{"uuid":"09e1557e-c84c-90f3-bc12-88fbdb31fd5e"},{"uuid":"8877cbde-0786-34a9-7ab2-bbeab81d7f8a"},{"uuid":"021a0181-4919-0be6-a4cb-ffdf3588bbb0"},{"uuid":"82a58227-7f71-ad90-7f7c-f5057e64cefc"},{"uuid":"00c6ca03-4d14-2e67-6a25-844f605c708e"},{"uuid":"b1acc977-a545-b2e9-15f8-2c0230d91100"},{"uuid":"0bd0a05d-0b97-d661-6478-fec8ed2be305"},{"uuid":"bf46866c-aece-a3f9-9702-d70d5939aac1"},{"uuid":"a6dce6d1-6677-6333-833f-0e8764384902"},{"uuid":"1eeb47f3-c65d-9979-bb17-e0c73c774e82"},{"uuid":"1058e12e-a8c5-4f09-deff-94dc1a34e1c2"},{"uuid":"9b8596be-3d62-8d79-c878-ccdd88955afb"},{"uuid":"4ef9641c-f53f-7266-361b-b11b77133968"},{"uuid":"70ded463-98b0-2f3e-990d-a4e27a289cf7"},{"uuid":"e651000a-d725-1296-9cec-e55b414ea215"},{"uuid":"7db8c140-f73f-7197-41b5-9596918bf44e"}]},"$adagio-formatVersion":55,"work":{"work-title":"Freedom 2040: The Tomorrow We'll Build Melody - Concert Pitch TC"}}}
+{
+    "score-partwise": {
+        "$version": "3.1",
+        "identification": {
+            "creator": {
+                "content": "Brittany J. Green",
+                "$type": "composer"
+            },
+            "encoding": {
+                "software": "Flat",
+                "encoding-date": "2023-12-03"
+            },
+            "source": "https://flat.io/score/62ec0df2c6f0b1001227613f-freedom-2040-the-tomorrow-we-ll-build-melody-concert-pitch-tc?sharingKey=30bc11ca0306e5d4955a135fd0bd723010fb082fe006f4dd505c36ade58ded13f494a810a480215bfe02b41e60f6972b5e69f40b5f2772291e75ada7fd8cd0b3"
+        },
+        "defaults": {
+            "scaling": {
+                "millimeters": "7.2319",
+                "tenths": "40"
+            },
+            "page-layout": {
+                "page-height": "1545",
+                "page-width": "1194",
+                "page-margins": {
+                    "$type": "both",
+                    "left-margin": "70",
+                    "right-margin": "70",
+                    "top-margin": "70",
+                    "bottom-margin": "70"
+                }
+            },
+            "system-layout": {
+                "system-margins": {
+                    "left-margin": "0",
+                    "right-margin": "0"
+                },
+                "system-distance": "121",
+                "top-system-distance": "70"
+            },
+            "appearance": {
+                "line-width": [
+                    {
+                        "content": "0.7487",
+                        "$type": "stem"
+                    },
+                    {
+                        "content": "5",
+                        "$type": "beam"
+                    },
+                    {
+                        "content": "0.7487",
+                        "$type": "staff"
+                    },
+                    {
+                        "content": "0.7487",
+                        "$type": "light barline"
+                    },
+                    {
+                        "content": "5",
+                        "$type": "heavy barline"
+                    },
+                    {
+                        "content": "0.7487",
+                        "$type": "leger"
+                    },
+                    {
+                        "content": "0.7487",
+                        "$type": "ending"
+                    },
+                    {
+                        "content": "0.7487",
+                        "$type": "wedge"
+                    },
+                    {
+                        "content": "0.7487",
+                        "$type": "enclosure"
+                    },
+                    {
+                        "content": "0.7487",
+                        "$type": "tuplet bracket"
+                    }
+                ],
+                "note-size": [
+                    {
+                        "content": "60",
+                        "$type": "grace"
+                    },
+                    {
+                        "content": "60",
+                        "$type": "cue"
+                    }
+                ],
+                "distance": [
+                    {
+                        "content": "120",
+                        "$type": "hyphen"
+                    },
+                    {
+                        "content": "7.5",
+                        "$type": "beam"
+                    }
+                ]
+            },
+            "music-font": {
+                "$font-family": "Bravura"
+            },
+            "staff-layout": {
+                "staff-distance": "70.24433413072636"
+            },
+            "$adagio-systemBreakPolicy": {
+                "maxNbMeasuresPerLine": 4,
+                "forbiddenCounts": {}
+            }
+        },
+        "credit": [
+            {
+                "credit-type": "title",
+                "credit-words": "Freedom 2040: The Tomorrow We'll Build Melody - Concert Pitch TC"
+            }
+        ],
+        "part-list": {
+            "score-part": [
+                {
+                    "$id": "P1",
+                    "part-name": {
+                        "content": "Concert Pitch",
+                        "$print-object": "no"
+                    },
+                    "part-abbreviation": {
+                        "content": "Ob.",
+                        "$print-object": "no"
+                    },
+                    "score-instrument": {
+                        "$id": "P1-I1",
+                        "instrument-name": "SmartMusicSoftSynth",
+                        "instrument-sound": "wind.reed.oboe",
+                        "virtual-instrument": {}
+                    },
+                    "midi-device": "SmartMusicSoftSynth",
+                    "midi-instrument": {
+                        "$id": "P1-I1",
+                        "midi-channel": "2",
+                        "midi-bank": "15489",
+                        "midi-program": 69,
+                        "pan": "-56"
+                    },
+                    "uuid": "b6e5faf5-e2d7-b2ab-0eaf-f6b5b8467ca8",
+                    "voiceMapping": {
+                        "0": [
+                            0
+                        ]
+                    },
+                    "staffMapping": [
+                        {
+                            "voices": [
+                                0
+                            ],
+                            "mainVoiceIdx": 0,
+                            "staffUuid": "74e64bc4-a81b-7f02-6ea3-61645a6a7739"
+                        }
+                    ],
+                    "voiceIdxToUuidMapping": {
+                        "0": "97cd248f-79db-20ff-cb25-904a5dc735de"
+                    },
+                    "voiceUuidToIdxMapping": {
+                        "97cd248f-79db-20ff-cb25-904a5dc735de": 0
+                    }
+                }
+            ]
+        },
+        "part": [
+            {
+                "$id": "P1",
+                "measure": [
+                    {
+                        "$number": "1",
+                        "$width": "178",
+                        "harmony": [
+                            {
+                                "$default-y": "39",
+                                "root": {
+                                    "root-step": "E",
+                                    "root-alter": "-1"
+                                },
+                                "kind": {
+                                    "content": "major",
+                                    "$halign": "center",
+                                    "$text": ""
+                                },
+                                "$adagio-location": {
+                                    "timePos": 0,
+                                    "dpq": 8
+                                },
+                                "staff": "1",
+                                "$placement": "above",
+                                "noteBefore": -1
+                            }
+                        ],
+                        "note": [
+                            {
+                                "staff": "1",
+                                "voice": "1",
+                                "duration": "8",
+                                "pitch": {
+                                    "octave": "4",
+                                    "step": "F"
+                                },
+                                "$adagio-location": {
+                                    "timePos": 0
+                                },
+                                "type": "quarter"
+                            },
+                            {
+                                "staff": "1",
+                                "voice": "1",
+                                "duration": "4",
+                                "pitch": {
+                                    "octave": "4",
+                                    "step": "G"
+                                },
+                                "$adagio-location": {
+                                    "timePos": 8
+                                },
+                                "type": "eighth",
+                                "beam": {
+                                    "$number": "1",
+                                    "content": "begin"
+                                }
+                            },
+                            {
+                                "staff": "1",
+                                "voice": "1",
+                                "duration": "4",
+                                "pitch": {
+                                    "octave": "4",
+                                    "step": "A",
+                                    "alter": "-1"
+                                },
+                                "$adagio-location": {
+                                    "timePos": 12
+                                },
+                                "type": "eighth",
+                                "beam": {
+                                    "$number": "1",
+                                    "content": "end"
+                                }
+                            },
+                            {
+                                "staff": "1",
+                                "voice": "1",
+                                "duration": "8",
+                                "pitch": {
+                                    "octave": "5",
+                                    "step": "C"
+                                },
+                                "$adagio-location": {
+                                    "timePos": 16
+                                },
+                                "type": "quarter"
+                            },
+                            {
+                                "staff": "1",
+                                "voice": "1",
+                                "duration": "8",
+                                "pitch": {
+                                    "octave": "4",
+                                    "step": "B",
+                                    "alter": "-1"
+                                },
+                                "$adagio-location": {
+                                    "timePos": 24
+                                },
+                                "type": "quarter"
+                            }
+                        ],
+                        "attributes": [
+                            {
+                                "divisions": "8",
+                                "time": {
+                                    "beats": "4",
+                                    "beat-type": "4"
+                                },
+                                "clef": {
+                                    "sign": "G",
+                                    "line": "2"
+                                },
+                                "key": {
+                                    "fifths": "-3"
+                                },
+                                "staff-details": {
+                                    "staff-lines": "5"
+                                },
+                                "$adagio-time": {
+                                    "beats": "4",
+                                    "beat-type": "4"
+                                },
+                                "noteBefore": -1,
+                                "$adagio-location": {
+                                    "timePos": 0,
+                                    "dpq": 1
+                                }
+                            }
+                        ],
+                        "$adagio-restsInsideBeams": false,
+                        "sound": [
+                            {
+                                "$adagio-swing": {
+                                    "swing": false
+                                },
+                                "noteBefore": -1,
+                                "$adagio-location": {
+                                    "timePos": 0,
+                                    "dpq": 8
+                                }
+                            },
+                            {
+                                "$tempo": "120",
+                                "noteBefore": -1,
+                                "$adagio-location": {
+                                    "timePos": 0,
+                                    "dpq": 8
+                                }
+                            }
+                        ],
+                        "direction": [
+                            {
+                                "$placement": "above",
+                                "staff": "1",
+                                "$adagio-location": {
+                                    "timePos": 0
+                                },
+                                "direction-type": {
+                                    "metronome": {
+                                        "per-minute": "120",
+                                        "beat-unit": "quarter"
+                                    }
+                                },
+                                "noteBefore": -1,
+                                "$adagio-isFirst": true
+                            }
+                        ],
+                        "$adagio-beatsList": [
+                            1,
+                            1,
+                            1,
+                            1
+                        ]
+                    }
+                ],
+                "uuid": "b6e5faf5-e2d7-b2ab-0eaf-f6b5b8467ca8"
+            }
+        ],
+        "measure-list": {
+            "score-measure": [
+                {
+                    "uuid": "09e1557e-c84c-90f3-bc12-88fbdb31fd5e"
+                },
+                {
+                    "uuid": "8877cbde-0786-34a9-7ab2-bbeab81d7f8a"
+                },
+                {
+                    "uuid": "021a0181-4919-0be6-a4cb-ffdf3588bbb0"
+                },
+                {
+                    "uuid": "82a58227-7f71-ad90-7f7c-f5057e64cefc"
+                },
+                {
+                    "uuid": "00c6ca03-4d14-2e67-6a25-844f605c708e"
+                },
+                {
+                    "uuid": "b1acc977-a545-b2e9-15f8-2c0230d91100"
+                },
+                {
+                    "uuid": "0bd0a05d-0b97-d661-6478-fec8ed2be305"
+                },
+                {
+                    "uuid": "bf46866c-aece-a3f9-9702-d70d5939aac1"
+                },
+                {
+                    "uuid": "a6dce6d1-6677-6333-833f-0e8764384902"
+                },
+                {
+                    "uuid": "1eeb47f3-c65d-9979-bb17-e0c73c774e82"
+                },
+                {
+                    "uuid": "1058e12e-a8c5-4f09-deff-94dc1a34e1c2"
+                },
+                {
+                    "uuid": "9b8596be-3d62-8d79-c878-ccdd88955afb"
+                },
+                {
+                    "uuid": "4ef9641c-f53f-7266-361b-b11b77133968"
+                },
+                {
+                    "uuid": "70ded463-98b0-2f3e-990d-a4e27a289cf7"
+                },
+                {
+                    "uuid": "e651000a-d725-1296-9cec-e55b414ea215"
+                },
+                {
+                    "uuid": "7db8c140-f73f-7197-41b5-9596918bf44e"
+                }
+            ]
+        },
+        "$adagio-formatVersion": 55,
+        "work": {
+            "work-title": "Freedom 2040: The Tomorrow We'll Build Melody - Concert Pitch TC"
+        }
+    }
+}

--- a/lib/variations.js
+++ b/lib/variations.js
@@ -6,6 +6,99 @@ import { hasBasePath } from "next/dist/server/router";
  *    - Adagio beat list (iirc name)
  */
 
+const template = JSON.parse(
+  JSON.stringify({
+    'score-partwise': {
+      'part-list': {
+        'score-part': [
+          {
+            'part-name': '',
+            voiceMapping: { 0: [0] },
+            staffMapping: [
+              {
+                mainVoiceIdx: 0,
+                voices: [0],
+                staffUuid: 'staffUuid',
+              },
+            ],
+            voiceIdxToUuidMapping: {
+              0: 'voiceUuid',
+            },
+            voiceUuidToIdxMapping: {
+              voiceUuid: 0,
+            },
+            'part-abbreviation': '',
+            'score-instrument': {
+              'instrument-name': '',
+              $id: 'P1-I1',
+            },
+
+            $id: 'P1',
+            uuid: 'P1',
+          },
+        ],
+      },
+      part: [
+        {
+          measure: [
+            {
+              note: [],
+              $number: '1',
+              barline: {
+                'bar-style': 'light-barline',
+                noteBefore: -1,
+              },
+              attributes: [
+                {
+                  "divisions": 0,
+                  time: { beats: '4', 'beat-type': '4' },
+                  clef: {},
+                  key: {},
+                  'staff-details': { 'staff-lines': '5' },
+                },
+              ],
+            },
+          ],
+          $id: 'P1',
+          uuid: 'P1',
+        },
+      ],
+    },
+  })
+);
+
+/**
+ * Takes a score and strips it of unnecessary properties, and rebuilds
+ * according to spec (e.g., 2/4 -> 4/4, uuid's removed)
+ * 
+ * 
+ * @param {*} orig the original score from flat
+ * @param {*} key the key; could omit and do this in the function, but it's even uglier code
+ * @param {*} clef the clef; could also omit
+ * @param {*} notes The student's motive (notes only), could omit
+ * @param {*} div The orig divisions, again, could omit
+ * @returns 
+ */
+function correctScore(orig, key, clef, notes, div) {
+  const origDupe = JSON.parse(JSON.stringify(orig));
+  const result   = JSON.parse(JSON.stringify(template));
+  const resultScorePart = result['score-partwise']['part-list']['score-part'][0];
+  const origScorePart   = origDupe['score-partwise']['part-list']['score-part'][0];
+
+  Object.keys(resultScorePart).forEach((key) => {
+    if (Object.hasOwn(origScorePart, key) && key != "uuid") {
+        resultScorePart[key] = origScorePart[key];
+      }
+  });
+
+  result['score-partwise']['part'][0].measure[0].attributes[0].clef = clef;
+  result['score-partwise']['part'][0].measure[0].attributes[0].key = key;
+  result['score-partwise']['part'][0].measure[0].attributes[0].divisions = "" + div;   // I think necessary for rendering
+  result['score-partwise']['part'][0].measure[0].note = [...notes];
+  console.log("score immediately after correction", result);
+  return result;
+}
+
 /**
  * given a measure, generate that measure's retrograde
  * 
@@ -44,6 +137,8 @@ function mwRetrograde(orig) {
  * rebuild given measure with attributes that are 
  * more in line for CPR's spec
  * 
+ * Still necessary despite template approach being taken
+ * 
  * @param {*} measure measure to be corrected
  * @returns           corrected measure
  */
@@ -51,7 +146,10 @@ function correctMeasure(measure) {
   const   defaultDiv = 2;                                       // the default division, assuming shifts will be no less than 8th note
   let alteredMeasure = JSON.parse(JSON.stringify(measure));     // deep copy
   let  origDivisions = alteredMeasure.attributes[0].divisions;  // the original division
-  let beatDivision   = defaultDiv / origDivisions;              // conversion factor for reconstruction
+  let   beatDivision = defaultDiv / origDivisions;              // conversion factor for reconstruction
+  console.log("beatDivision", beatDivision);
+  console.log("origDivisions", alteredMeasure.attributes[0].divisions);
+  console.log("inside correctMeasure measure", JSON.parse(JSON.stringify(alteredMeasure)));
 
   // check if reconstruction necessary
   let modify = origDivisions != defaultDiv && (alteredMeasure.attributes[0].divisions = defaultDiv);
@@ -79,7 +177,7 @@ function mwRhythmicShift(orig, shift) {
   const numNotes = orig.note.length;                  // original # of notes
   const adjShift = Math.ceil(shift / measure.attributes[0].divisions);    // adjusted shift (for splitting)
   const maxNotes = orig.attributes[0].time.beats * measure.attributes[0].divisions;   // max # notes possible (restricted to 8ths)
-  console.log(`For shift = ${shift}, reconstructed single measure: `, measure);
+  console.log(`For shift = ${shift}, orig measure: `, measure);
   console.log("Number of notes in incoming measure: ", numNotes);
   console.log(`Passed Shift: ${shift}\nAdjusted Shift: ${adjShift}`);
   console.log("Maximum number of notes: ", maxNotes);
@@ -158,8 +256,8 @@ function mwMelodicShift(orig, shift) {
  */
 function mwRhythmicMelodicShift(orig, shift) {
   let result = JSON.parse(JSON.stringify(orig));
-  result = mwRhythmicShift(result, shift);
-  result = mwMelodicShift(result, shift);
+  result     = mwRhythmicShift(result, shift);
+  result     = mwMelodicShift(result, shift);
   return result;
 }
 
@@ -187,8 +285,17 @@ Array.prototype.addAll = function(elements) {
  */
 function mwMergeVariations(orig, measures) {
   const result = JSON.parse(JSON.stringify(orig));
+  measures.forEach((measure) => {
+    measure.note.forEach((note) => {
+      note.duration = note.duration.toString();
+      note.type = note.duration === "1" ? "eighth" : "quarter";
+    });
+    measure.attributes[0].divisions = measure.attributes[0].divisions.toString(); 
+  });
+  console.log("after merge modifications", measures);
   result['score-partwise'].part[0].measure = [...measures];
   result['score-partwise']['part-list']["score-part"].uuid = "variations";
+
   return result;
 }
 
@@ -213,26 +320,41 @@ function mwCreateVariations(origStr) {
   if (!orig || !Object.hasOwn(orig, 'score-partwise'))
     return null
 
-  const origMeasure = orig['score-partwise'].part[0].measure[0];
-  const corrected = correctMeasure(origMeasure);
+  const key   = orig['score-partwise'].part[0].measure[0].attributes[0]['key'];
+  const clef  = orig['score-partwise'].part[0].measure[0].attributes[0]['clef'];
+  const divs  = orig['score-partwise'].part[0].measure[0].attributes[0].divisions;
+  const notes = orig['score-partwise'].part[0].measure[0].note;
+  const correctedScore   = correctScore(orig, key, clef, notes, divs);            // correct the whole score 
+  const givenMeasure     = correctedScore['score-partwise'].part[0].measure[0];   // grab the motive...
+  const correctedMeasure = correctMeasure(givenMeasure);                          // ...then correct it
+  console.log("incoming score", orig);
+  console.log("outgoing key", key);
+  console.log("outgoing clef", clef);
+  console.log("corrected score", correctedScore);
+  console.log("given measure", givenMeasure);
+  console.log("corrected measure", correctedMeasure);
 
   const measures = [];
   measures.addAll([
-      corrected,
-      mwRetrograde(JSON.parse(JSON.stringify(corrected))),   // why *another* deepcopy??
-      mwRhythmicShift(corrected, 1),
-      mwRhythmicShift(corrected, 2),
-      mwRhythmicShift(corrected, 3),
-      mwMelodicShift(corrected, 1),
-      mwMelodicShift(corrected, 2),
-      mwMelodicShift(corrected, 3),
-      mwRhythmicMelodicShift(corrected, 1),
-      mwRhythmicMelodicShift(corrected, 2),
-      mwRhythmicMelodicShift(corrected, 3),
-    ]);
+      correctedMeasure,
+      mwRetrograde(JSON.parse(JSON.stringify(correctedMeasure))),   // why *another* deepcopy??
+      mwRhythmicShift(correctedMeasure, 1),
+      mwRhythmicShift(correctedMeasure, 2),
+      mwRhythmicShift(correctedMeasure, 3),
+      mwMelodicShift(correctedMeasure, 1),
+      mwMelodicShift(correctedMeasure, 2),
+      mwMelodicShift(correctedMeasure, 3),
+      mwRhythmicMelodicShift(correctedMeasure, 1),
+      mwRhythmicMelodicShift(correctedMeasure, 2),
+      mwRhythmicMelodicShift(correctedMeasure, 3),
+  ]);
 
-    const  result = mwMergeVariations(orig, measures);
-    return result;
+  // ensure final measure has the correct type of barline
+  measures[measures.length - 1].barline['bar-style'] = 'light-heavy';
+
+  const  result = mwMergeVariations(correctedScore, measures);
+  console.log("returning from createVariations", result);
+  return result;
 }
 
 export {


### PR DESCRIPTION
- Exploratory takes the flat score presented to students, strips it of properties which are unnecessary for the activity and sets up as template in which generated variations will be placed. 
    - fixes the issue with tempos not propagating to resulting score
    - this resolves the scores not loading due to uuid's clashing (assuming that's what was causing it)
- if 2/4 is eventually added back in, basis for 'converting' to 4/4 is now there. The student's compose editor is still in 2/4 right now since the plan is to omit 2/4 for now.
- commented out some logs that were flooding the console.
- have not yet resolved eighth motive ending on eighths issue
- 