### PR TITLE
Think it's finally fixed

### DIFF
--- a/lib/variations.js
+++ b/lib/variations.js
@@ -1,72 +1,5 @@
 import { hasBasePath } from "next/dist/server/router";
 
-/* For 2/4, consider checking attributes:
- *    - beat-type
- *    - beats
- *    - Adagio beat list (iirc name)
- */
-
-const template = JSON.parse(
-  JSON.stringify({
-    'score-partwise': {
-      'part-list': {
-        'score-part': [
-          {
-            'part-name': '',
-            voiceMapping: { 0: [0] },
-            staffMapping: [
-              {
-                mainVoiceIdx: 0,
-                voices: [0],
-                staffUuid: 'staffUuid',
-              },
-            ],
-            voiceIdxToUuidMapping: {
-              0: 'voiceUuid',
-            },
-            voiceUuidToIdxMapping: {
-              voiceUuid: 0,
-            },
-            'part-abbreviation': '',
-            'score-instrument': {
-              'instrument-name': '',
-              $id: 'P1-I1',
-            },
-
-            $id: 'P1',
-            uuid: 'P1',
-          },
-        ],
-      },
-      part: [
-        {
-          measure: [
-            {
-              note: [],
-              $number: '1',
-              barline: {
-                'bar-style': 'light-barline',
-                noteBefore: -1,
-              },
-              attributes: [
-                {
-                  "divisions": 0,
-                  time: { beats: '4', 'beat-type': '4' },
-                  clef: {},
-                  key: {},
-                  'staff-details': { 'staff-lines': '5' },
-                },
-              ],
-            },
-          ],
-          $id: 'P1',
-          uuid: 'P1',
-        },
-      ],
-    },
-  })
-);
-
 /**
  * Takes a score and strips it of unnecessary properties, and rebuilds
  * according to spec (e.g., 2/4 -> 4/4, uuid's removed)
@@ -175,15 +108,19 @@ function correctMeasure(measure) {
 function mwRhythmicShift(orig, shift) {
   const  measure = JSON.parse(JSON.stringify(orig));  // deep copy
   const numNotes = orig.note.length;                  // original # of notes
-  const adjShift = Math.ceil(shift / measure.attributes[0].divisions);    // adjusted shift (for splitting)
-  const maxNotes = orig.attributes[0].time.beats * measure.attributes[0].divisions;   // max # notes possible (restricted to 8ths)
+
+  const maxNotes  = orig.attributes[0].time.beats * measure.attributes[0].divisions;   // max # notes possible (restricted to 8ths)
+  let pitchList   = [...measure.note];
+
+  // if student motive ends on eighths...
+  const bypassAdj = shift > 1 && pitchList[pitchList.length - 1].duration == 1;
+  // .. bypass shift adjustment for shifts by 2 & 3
+  const adjShift  = bypassAdj ? shift : Math.ceil(shift / measure.attributes[0].divisions);  
+  let checkList   = pitchList.splice(numNotes - adjShift);
   console.log(`For shift = ${shift}, orig measure: `, measure);
   console.log("Number of notes in incoming measure: ", numNotes);
   console.log(`Passed Shift: ${shift}\nAdjusted Shift: ${adjShift}`);
   console.log("Maximum number of notes: ", maxNotes);
-
-  let pitchList = [...measure.note]
-  let checkList = pitchList.splice(numNotes - adjShift);
 
   const updateTimePos = (note) => {
     note['oPos'] = note['$adagio-location'].timePos;                // original position 
@@ -209,6 +146,7 @@ function mwRhythmicShift(orig, shift) {
       splitNote['$adagio-location'].timePos = splitNote.uPos;
       splitNote.duration -= 1;
       note.duration -= 1;
+      note.split = true;
 
       pitchList.push(splitNote);
     }
@@ -334,6 +272,25 @@ function mwCreateVariations(origStr) {
   console.log("given measure", givenMeasure);
   console.log("corrected measure", correctedMeasure);
 
+  // alternate solution to 8ths bug - does not coalesce yet, and feels lazy. BUT
+  // bit of pseudo-memoization ? 
+  // const r1 = mwRhythmicShift(correctedMeasure, 1);
+  // const r2 = mwRhythmicShift(r1, 1);
+  // const r3 = mwRhythmicShift(r2, 1);
+  // const m1 = mwMelodicShift(correctedMeasure, 1);
+  // const m2 = mwMelodicShift(m1, 1);
+  // const m3 = mwMelodicShift(m2, 1);
+  // const mr1 = mwRhythmicMelodicShift(correctedMeasure, 1);
+  // const mr2= mwRhythmicMelodicShift(mr1, 1);
+  // const mr3= mwRhythmicMelodicShift(mr2, 1);
+
+  // const measures = [];
+  // measures.addAll([
+  //     correctedMeasure,
+  //     mwRetrograde(JSON.parse(JSON.stringify(correctedMeasure))),   // why *another* deepcopy??
+  //     r1, r2, r3, m1, m2, m3, mr1, mr2, mr3
+  // ]);
+
   const measures = [];
   measures.addAll([
       correctedMeasure,
@@ -364,3 +321,66 @@ export {
   mwRhythmicMelodicShift,
   mwCreateVariations,
 };
+
+const template = JSON.parse(
+  JSON.stringify({
+    'score-partwise': {
+      'part-list': {
+        'score-part': [
+          {
+            'part-name': '',
+            voiceMapping: { 0: [0] },
+            staffMapping: [
+              {
+                mainVoiceIdx: 0,
+                voices: [0],
+                staffUuid: 'staffUuid',
+              },
+            ],
+            voiceIdxToUuidMapping: {
+              0: 'voiceUuid',
+            },
+            voiceUuidToIdxMapping: {
+              voiceUuid: 0,
+            },
+            'part-abbreviation': '',
+            'score-instrument': {
+              'instrument-name': '',
+              $id: 'P1-I1',
+            },
+
+            $id: 'P1',
+            uuid: 'P1',
+          },
+        ],
+      },
+      part: [
+        {
+          measure: [
+            {
+              note: [],
+              $number: '1',
+              barline: {
+                'bar-style': 'light-barline',
+                noteBefore: -1,
+              },
+              attributes: [
+                {
+                  "divisions": 0,
+                  time: { beats: '4', 'beat-type': '4' },
+                  clef: {},
+                  key: {},
+                  'staff-details': { 'staff-lines': '5' },
+                },
+              ],
+              // sound: [],
+              // direction: [],
+            },
+          ],
+          $id: 'P1',
+          uuid: 'P1',
+        },
+      ],
+    },
+  })
+);


### PR DESCRIPTION
Now `variations.js`:

- takes the orig motive
- strips everything from the json that is understood (at this moment) to be unnecessary
- no longer throws a fit over `uuid` inconsistencies
- in each algo, only single measures are operated on
- still coalesces when quarter split and shift causes adjacency
- *doesn't have a tantrum when measures end in 8ths*
- merges the 11 + 1 measures

`variations.js` does not (yet):

- check colors
- handle syncopation (not tested. not hopeful)
   - that said if syncopation is allowed you risk ending up with 16th after split
       - (b/c dotted 8th = 8th + 16th; shift of one 8th leaves only one 16th)
- sounding


Some spots could be cleaned up/made less crufty

The 8ths issue was something I think I had accounted for in a very early version of this but got forgotten during the various evolutions. The adjusted shift must be bypassed for shifts > 1 if the original score ends on an 8th note.